### PR TITLE
Exclude MaxLineLength on Tests

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -551,6 +551,7 @@ style:
   MandatoryBracesLoops:
     active: false
   MaxLineLength:
+    excludes: [ '**/test/**', '**/*.Test.kt' ]
     active: true
     maxLineLength: 120
     excludePackageStatements: true


### PR DESCRIPTION
That fix exclude "MaxLineLenght" from detekt on tests classes